### PR TITLE
bugfixed: fetching breaks when large message sent slowly from Stomp server

### DIFF
--- a/run_phpunit.sh
+++ b/run_phpunit.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-./vendor/bin/phpunit --no-configuration tests/Unit/Stomp
+./vendor/bin/phpunit --no-configuration tests/Unit

--- a/src/Network/Connection.php
+++ b/src/Network/Connection.php
@@ -546,7 +546,7 @@ class Connection
             if ($frame = $this->parser->nextFrame()) {
                 return $this->onFrame($frame);
             }
-        } while ($this->isDataOnStream());
+        } while ($this->hasDataToRead());
 
         return false;
     }
@@ -684,7 +684,7 @@ class Connection
             $this->writeData(self::ALIVE, $timeout);
         }
     }
-    
+
     /**
      * Immediately releases all allocated resources when the connection object gets destroyed.
      *


### PR DESCRIPTION
When stomp server has not already sent next chunk of the data, we wait for this chunk using Connection::hasDataToRead. Thanks to this, downloading a large message works properly.